### PR TITLE
Fix EXX and EX A AF,AF' not updating internal flag and JAF and JAR not working

### DIFF
--- a/z280/z280ops.h
+++ b/z280/z280ops.h
@@ -915,7 +915,7 @@ INLINE UINT8 DEC(struct z280_state *cpustate, UINT8 value)
 #define EX_AF {                                                 \
 	union PAIR tmp;                                                   \
 	tmp = cpustate->AF; cpustate->AF = cpustate->AF2; cpustate->AF2 = tmp;          \
-	cpustate->AF2inuse = !!cpustate->AF2inuse;                  \
+	cpustate->AF2inuse = ~cpustate->AF2inuse;                  \
 }
 
 /***************************************************************
@@ -934,7 +934,7 @@ INLINE UINT8 DEC(struct z280_state *cpustate, UINT8 value)
 	tmp = cpustate->BC; cpustate->BC = cpustate->BC2; cpustate->BC2 = tmp;          \
 	tmp = cpustate->DE; cpustate->DE = cpustate->DE2; cpustate->DE2 = tmp;          \
 	tmp = cpustate->HL; cpustate->HL = cpustate->HL2; cpustate->HL2 = tmp;          \
-	cpustate->BC2inuse = !!cpustate->BC2inuse;                  \
+	cpustate->BC2inuse = ~cpustate->BC2inuse;                  \
 }
 
 /***************************************************************


### PR DESCRIPTION
Fixes https://github.com/mtdev79/z280emu/issues/7. For reference:

There's a bug in the implementation of the `EX AF,AF'` and `EXX`  instructions that causes the `AF2inuse` and `BC2inuse` fields in the `z280_state` struct to never be updated, this causes the `JAF` and `JAR` instructions to fail (they never jump). This is how `EX AF,AF'` is implemented:

```C
#define EX_AF {                                                 \
	union PAIR tmp;                                                   \
	tmp = cpustate->AF; cpustate->AF = cpustate->AF2; cpustate->AF2 = tmp;          \
	cpustate->AF2inuse = !!cpustate->AF2inuse;                  \
}
```

That `!!` in the last line should be `~`. And the same for `EXX`.

I have unit tests in [my .NET wrapper project](https://github.com/Konamiman/Z280emuDotNet) to verify this behavior: with the original code the tests fail, replacing `!!` with `~`  the tests pass. For reference, here's one of the tests:

```c#
[Test]
public void TestJarAndJaf()
{
    AssembleAndRun(@"
        ld b,1
        jaf JUMP_1
        ld b,2
    JUMP_1:

        ex af,af

        ld c,1
        jaf JUMP_2
        ld c,2
    JUMP_2:

        ld ix,1
        jar JUMP_3
        ld ix,2
    JUMP_3:

        exx

        ld iy,1
        jar JUMP_4
        ld iy,2
    JUMP_4:

        exx
        ret");

    Assert.That(z280.B, Is.EqualTo(2));
    Assert.That(z280.C, Is.EqualTo(1));
    Assert.That(z280.IX, Is.EqualTo(2));
    Assert.That(z280.IY, Is.EqualTo(1));
}
```